### PR TITLE
Optional limitation to bomb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lita-pugbomb
 
-**lita-pugbomb** is a handler for [Lita](https://github.com/jimmycuadra/lita) that displays an arbitrary number of images of pugs, via [this single-serving Heroku app](http://pugme.herokuapp.com). 
+**lita-pugbomb** is a handler for [Lita](https://github.com/jimmycuadra/lita) that displays an arbitrary number of images of pugs, via [this single-serving Heroku app](http://pugme.herokuapp.com).
 
 Sometimes you'd just rather see an array of pugs than whatever else is currently in chat.
 
@@ -20,4 +20,19 @@ gem "lita-pugbomb"
 
 `Lita: how many pugs are there` - you can figure it out
 
+### Optional `MAX_PUGS` environment variable
 
+You can optionally set a `MAX_PUGS` environment variable. This variable will limitate how many pugs the command 'pug bomb' will send.
+
+For example:
+
+- With `MAX_PUGS='3'`
+  - `pug bomb` will respond with 3 pugs
+  - `pug bomb 2` will respond with 2 pugs
+  - `pug bomb 10` will respond wih 3 pugs
+
+
+- Without `MAX_PUGS` value
+  - `pug bomb` will respond with 5 pugs
+  - `pug bomb 2` will respond with 2 pugs
+  - `pug bomb 10` will respond wih 10 pugs

--- a/lib/lita/handlers/pugbomb.rb
+++ b/lib/lita/handlers/pugbomb.rb
@@ -15,7 +15,7 @@ module Lita
       end
 
       def bomb(response)
-        count = response.matches[0][1] || 5
+        count = pug_quantity(response.matches[0][1])
         data = MultiJson.load(http.get(BASE_URL + "/bomb", count: count).body)
         data['pugs'].each do |pug|
           response.reply pug
@@ -27,7 +27,17 @@ module Lita
         pug_count = data['pug_count']
         response.reply "There are #{pug_count} pugs."
       end
+
+      private
+
+      def pug_quantity(quantity)
+        quantity ||= 5
+        return quantity unless ENV['MAX_PUGS']
+
+        quantity.to_i <= ENV['MAX_PUGS'].to_i ? quantity : ENV['MAX_PUGS']
+      end
     end
+
     Lita.register_handler(Pugbomb)
   end
 end

--- a/spec/lita/handlers/pugbomb_spec.rb
+++ b/spec/lita/handlers/pugbomb_spec.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'spec_helper'
 
 describe Lita::Handlers::Pugbomb, lita_handler: true do
@@ -34,6 +35,61 @@ describe Lita::Handlers::Pugbomb, lita_handler: true do
     end
   end
 
+  describe "#bomb with limit" do
+    let(:bomb) do
+      {
+        pugs: [
+          "http://28.media.tumblr.com/tumblr_ltef3eghZ71qb08qmo1_500.jpg",
+          "http://28.media.tumblr.com/tumblr_lk5h7hIRFf1qi4pifo1_500.jpg",
+          "http://28.media.tumblr.com/tumblr_lk5h7hIRFf1qi4pifo1_500.jpg",
+          "http://28.media.tumblr.com/tumblr_lk5h7hIRFf1qi4pifo1_500.jpg",
+          "http://28.media.tumblr.com/tumblr_lk5h7hIRFf1qi4pifo1_500.jpg"
+        ]
+      }.to_json
+    end
+
+    before do
+      allow_any_instance_of(Faraday::Connection).to receive(:get).with("http://pugme.herokuapp.com/bomb", count: "5").and_return(double("Faraday::Response", status: 200, body: bomb))
+      stub_const('ENV', { 'MAX_PUGS' => '5' })
+    end
+
+    it "replies with enviroment variable quantity" do
+      expect {
+        send_command("pug bomb 10")
+      }.to change{replies.count}.by(5)
+    end
+  end
+
+  describe "#bomb without limit" do
+    let(:bomb) do
+      {
+        pugs: [
+          "http://28.media.tumblr.com/tumblr_ltef3eghZ71qb08qmo1_500.jpg",
+          "http://28.media.tumblr.com/tumblr_lk5h7hIRFf1qi4pifo1_500.jpg",
+          "http://28.media.tumblr.com/tumblr_lk5h7hIRFf1qi4pifo1_500.jpg",
+          "http://28.media.tumblr.com/tumblr_lk5h7hIRFf1qi4pifo1_500.jpg",
+          "http://28.media.tumblr.com/tumblr_lk5h7hIRFf1qi4pifo1_500.jpg",
+          "http://28.media.tumblr.com/tumblr_lk5h7hIRFf1qi4pifo1_500.jpg",
+          "http://28.media.tumblr.com/tumblr_lk5h7hIRFf1qi4pifo1_500.jpg",
+          "http://28.media.tumblr.com/tumblr_lk5h7hIRFf1qi4pifo1_500.jpg",
+          "http://28.media.tumblr.com/tumblr_lk5h7hIRFf1qi4pifo1_500.jpg",
+          "http://28.media.tumblr.com/tumblr_lk5h7hIRFf1qi4pifo1_500.jpg"
+        ]
+      }.to_json
+    end
+
+    before do
+      allow_any_instance_of(Faraday::Connection).to receive(:get).with("http://pugme.herokuapp.com/bomb", count: "10").and_return(double("Faraday::Response", status: 200, body: bomb))
+      stub_const('ENV', { 'MAX_PUGS' => nil })
+    end
+
+    it "replies with n pugs" do
+      expect {
+        send_command("pug bomb 10")
+      }.to change{replies.count}.by(10)
+    end
+  end
+
   describe "#count" do
     let(:count) { '{"pug_count": 298}' }
     before do
@@ -41,7 +97,7 @@ describe Lita::Handlers::Pugbomb, lita_handler: true do
     end
 
     it "replies with the current pug count" do
-      send_command("how many pugs are there") 
+      send_command("how many pugs are there")
       expect(replies.last).to include("There are 298 pugs")
     end
   end


### PR DESCRIPTION
### Motivation

I've noted that there's no kind of limitation to command `pug bomb <number>` and it may cause some spamming depending of the number passed to command.

### Proposed solution

Added support to `MAX_PUGS` environment variable that, when it's setted, limit the quantity of pugs sended by `pug bomb` command.